### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - run: |
-        GH_RELEASE="https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ inputs.tag }}"
+        GH_RELEASE=$(sed s#/refs/tags## <<< "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ inputs.tag }}")
         upload_url=$(curl -s --request GET --url $GH_RELEASE | grep -oP '(?<="upload_url": ")[^"]*' | cut -d'{' -f1)
         j=0
         if [ -d ${{ inputs.asset-path }} ]; then


### PR DESCRIPTION
Strip out /refs/tags prefix from GH_RELEASE to enable using ${{ github.ref }}.

Fixes #1